### PR TITLE
:zap: Optimize grayscale to avoid callstack error

### DIFF
--- a/npz_viewer_client/components/dashboard/charts/greyscale.tsx
+++ b/npz_viewer_client/components/dashboard/charts/greyscale.tsx
@@ -1,55 +1,61 @@
-import { useRef, useEffect } from 'react'
+import { useRef, useEffect } from "react";
 
 interface GrayscaleImageProps {
-  data: number[][]
+  data: number[][];
 }
 
 export default function GrayscaleImage({ data }: GrayscaleImageProps) {
-  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const canvasRef = useRef<HTMLCanvasElement>(null);
 
   useEffect(() => {
-    if (!data || data.length === 0 || !canvasRef.current) return
+    if (!data || data.length === 0 || !canvasRef.current) return;
 
-    const canvas = canvasRef.current
-    const ctx = canvas.getContext('2d')
-
-    if (!ctx) return
+    const canvas = canvasRef.current;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
 
     // Set canvas dimensions based on the array size
-    const rows = data.length
-    const cols = data[0].length
-    canvas.width = cols
-    canvas.height = rows
+    const rows = data.length;
+    const cols = data[0].length;
+    canvas.width = cols;
+    canvas.height = rows;
 
-    // Normalize data to grayscale (0-255)
-    const flatData = data.flat()
-    const maxVal = Math.max(...flatData)
-    const minVal = Math.min(...flatData)
-    const normalize = (value: number) =>
-      Math.round(((value - minVal) / (maxVal - minVal)) * 255)
+    // Compute min and max values with a simple nested loop to avoid spreading a large array
+    let minVal = Infinity;
+    let maxVal = -Infinity;
+    for (let i = 0; i < rows; i++) {
+      for (let j = 0; j < cols; j++) {
+        const value = data[i][j];
+        if (value < minVal) minVal = value;
+        if (value > maxVal) maxVal = value;
+      }
+    }
+    // Avoid division by zero if all values are equal
+    const range = maxVal - minVal || 1;
 
     // Create image data
-    const imageData = ctx.createImageData(cols, rows)
-    let index = 0
-    for (let row = 0; row < rows; row++) {
-      for (let col = 0; col < cols; col++) {
-        const grayscaleValue = normalize(data[row][col])
-        imageData.data[index++] = grayscaleValue // Red
-        imageData.data[index++] = grayscaleValue // Green
-        imageData.data[index++] = grayscaleValue // Blue
-        imageData.data[index++] = 255 // Alpha (fully opaque)
+    const imageData = ctx.createImageData(cols, rows);
+    let index = 0;
+    for (let i = 0; i < rows; i++) {
+      for (let j = 0; j < cols; j++) {
+        const normalizedValue = Math.round(
+          ((data[i][j] - minVal) / range) * 255,
+        );
+        imageData.data[index++] = normalizedValue; // Red
+        imageData.data[index++] = normalizedValue; // Green
+        imageData.data[index++] = normalizedValue; // Blue
+        imageData.data[index++] = 255; // Alpha (fully opaque)
       }
     }
 
     // Draw image on canvas
-    ctx.putImageData(imageData, 0, 0)
-  }, [data])
+    ctx.putImageData(imageData, 0, 0);
+  }, [data]);
 
   return (
-    <div className='w-full'>
+    <div className="w-full">
       <h3 className="text-lg font-semibold mb-2">Grayscale Image</h3>
       <canvas ref={canvasRef} className="border w-full" />
     </div>
-  )
+  );
 }
-


### PR DESCRIPTION
- Removed usage of the spread operator to flatten the 2D array, which was causing
      the "Maximum call stack size exceeded" error.
    - Implemented nested loops to compute the min and max values of the grayscale data.
    - Added a guard to handle cases where all data values are equal to avoid division by zero.
    - Ensured proper normalization of grayscale values before drawing to the canvas.