### PR TITLE
:recycle: optimize Table2D component with memoization

### DIFF
--- a/npz_viewer_client/components/dashboard/data-table/Table2d.tsx
+++ b/npz_viewer_client/components/dashboard/data-table/Table2d.tsx
@@ -1,3 +1,4 @@
+import React, { useMemo, memo } from "react";
 import {
   Table,
   TableBody,
@@ -12,31 +13,50 @@ interface Table2DProps {
   fileName: string;
 }
 
-export default function Table2D({ data }: Table2DProps) {
+// A memoized row component to avoid unnecessary re-renders when its props do not change
+const MemoizedTableRow: React.FC<{ row: number[] }> = memo(({ row }) => {
+  return (
+    <TableRow>
+      {row.map((cell, cellIndex) => (
+        <TableCell key={cellIndex} className="text-center">
+          {typeof cell === "number" ? cell.toFixed(4) : cell}
+        </TableCell>
+      ))}
+    </TableRow>
+  );
+});
+
+const Table2D: React.FC<Table2DProps> = ({ data }) => {
+  // Memoize header cells so they are only recalculated if the data changes
+  const headerCells = useMemo(
+    () =>
+      data[0].map((_, colIndex) => (
+        <TableHead key={colIndex} className="text-center">
+          Column {colIndex + 1}
+        </TableHead>
+      )),
+    [data]
+  );
+
+  // Memoize table rows
+  const tableRows = useMemo(
+    () =>
+      data.map((row, rowIndex) => (
+        <MemoizedTableRow key={rowIndex} row={row} />
+      )),
+    [data]
+  );
+
   return (
     <div>
       <Table>
         <TableHeader>
-          <TableRow>
-            {data[0].map((_, colIndex) => (
-              <TableHead key={colIndex} className="text-center">
-                Column {colIndex + 1}
-              </TableHead>
-            ))}
-          </TableRow>
+          <TableRow>{headerCells}</TableRow>
         </TableHeader>
-        <TableBody>
-          {data.map((row, rowIndex) => (
-            <TableRow key={rowIndex}>
-              {row.map((cell, cellIndex) => (
-                <TableCell key={cellIndex} className="text-center">
-                  {typeof cell === "number" ? cell.toFixed(4) : cell}
-                </TableCell>
-              ))}
-            </TableRow>
-          ))}
-        </TableBody>
+        <TableBody>{tableRows}</TableBody>
       </Table>
     </div>
   );
-}
+};
+
+export default memo(Table2D);


### PR DESCRIPTION
Memoize the header cells and table rows in the Table2D component to 
reduce unnecessary re-renders. Introduce a MemoizedTableRow component 
to enhance performance by preventing re-renders when row props remain 
unchanged. This improves rendering efficiency and responsiveness 
when dealing with large datasets.